### PR TITLE
refactor: remove several dependencies

### DIFF
--- a/AddressLibDecoder/CMakeLists.txt
+++ b/AddressLibDecoder/CMakeLists.txt
@@ -8,12 +8,10 @@ add_project(
 		"src/main.cpp"
 )
 
-find_package(fmt REQUIRED CONFIG)
 find_package(mmio REQUIRED CONFIG)
 
 target_link_libraries(
 	"${PROJECT_NAME}"
 	PUBLIC
-		fmt::fmt
 		mmio::mmio
 )

--- a/AddressLibDecoder/README.md
+++ b/AddressLibDecoder/README.md
@@ -1,3 +1,2 @@
 ## Build Dependencies
-* [fmt](https://github.com/fmtlib/fmt)
 * [mmio](https://github.com/Ryan-rsm-McKenzie/mmio)

--- a/AddressLibDecoder/src/main.cpp
+++ b/AddressLibDecoder/src/main.cpp
@@ -1,17 +1,14 @@
 #pragma warning(push)
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
-#include <utility>
 
-#include <fmt/format.h>
 #include <mmio/mmio.hpp>
 #pragma warning(pop)
 
@@ -45,10 +42,10 @@ int main(int a_argc, char* a_argv[])
 				reinterpret_cast<const Pair*>(input.data() + sizeof(std::uint64_t)),
 				*reinterpret_cast<const std::uint64_t*>(input.data()));
 			if (!data.empty()) {
-				const auto width = fmt::format(FMT_STRING("{}"), data.back().id);
-				const auto format = fmt::format(FMT_STRING("{{: >{}}}\t{{:0>7X}}\n"), width.length());
-				for (const auto& elem : data) {
-					output << fmt::format(fmt::runtime(format), elem.id, elem.offset);
+				const auto width = std::format("{}", data.back().id);
+				const auto format = std::format("{{: >{}}}\t{{:0>7X}}\n", width.length());
+				for (const auto& [id, offset] : data) {
+					output << std::vformat(format, std::make_format_args(id, offset));
 				}
 			}
 

--- a/AddressLibGen/CMakeLists.txt
+++ b/AddressLibGen/CMakeLists.txt
@@ -8,12 +8,10 @@ add_project(
 		"src/main.cpp"
 )
 
-find_package(robin_hood REQUIRED CONFIG)
 find_package(srell MODULE REQUIRED)
 
 target_link_libraries(
 	"${PROJECT_NAME}"
 	PRIVATE
-		robin_hood::robin_hood
 		srell::srell
 )

--- a/AddressLibGen/README.md
+++ b/AddressLibGen/README.md
@@ -1,3 +1,2 @@
 ## Build Dependencies
-* [robin-hood-hashing](https://github.com/martinus/robin-hood-hashing)
 * [SRELL](https://www.akenotsuki.com/misc/srell/en/)

--- a/AddressLibGen/src/main.cpp
+++ b/AddressLibGen/src/main.cpp
@@ -16,10 +16,10 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
-#include <robin_hood.h>
 #include <srell.hpp>
 #pragma warning(pop)
 
@@ -145,8 +145,7 @@ using files_t = std::vector<std::tuple<Version, Version, std::filesystem::path>>
 	return results;
 }
 
-using offset_map = robin_hood::unordered_node_map<std::uint64_t, Mapping>;
-//using offset_map = std::unordered_map<std::uint64_t, Mapping>;
+using offset_map = std::unordered_map<std::uint64_t, Mapping>;
 using version_map = std::map<Version, offset_map>;
 
 [[nodiscard]] version_map load_mappings(const files_t& a_files)

--- a/CommonLibF4/CMakeLists.txt
+++ b/CommonLibF4/CMakeLists.txt
@@ -14,7 +14,6 @@ if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
 endif()
 
 find_package(Boost MODULE REQUIRED)
-find_package(fmt REQUIRED CONFIG)
 find_package(mmio REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 
@@ -97,7 +96,6 @@ target_link_libraries(
 	PUBLIC
 		bcrypt.lib
 		Boost::headers
-		fmt::fmt
 		mmio::mmio
 		spdlog::spdlog
 		Version.lib

--- a/CommonLibF4/CMakeLists.txt
+++ b/CommonLibF4/CMakeLists.txt
@@ -72,6 +72,7 @@ if (MSVC)
 			/wd4625 # 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
 			/wd4626 # 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
 			/wd4686 # 'user-defined type' : possible change in behavior, change in UDT return calling convention
+			/wd4702 # unreachable code
 			/wd4710 # 'function' : function not inlined
 			/wd4711 # function 'function' selected for inline expansion
 			/wd4820 # 'bytes' bytes padding added after construct 'member_name'

--- a/CommonLibF4/README.md
+++ b/CommonLibF4/README.md
@@ -1,6 +1,5 @@
 ## Build Dependencies
 * [Boost](https://www.boost.org/)
 	* Stl_interfaces
-* [fmt](https://github.com/fmtlib/fmt)
 * [mmio](https://github.com/Ryan-rsm-McKenzie/mmio)
 * [spdlog](https://github.com/gabime/spdlog)

--- a/CommonLibF4/cmake/config.cmake.in
+++ b/CommonLibF4/cmake/config.cmake.in
@@ -2,6 +2,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 include(CMakeFindDependencyMacro)
 
 find_dependency(Boost MODULE)
-find_dependency(fmt CONFIG)
 find_dependency(mmio CONFIG)
 find_dependency(spdlog CONFIG)

--- a/CommonLibF4/include/F4SE/Impl/PCH.h
+++ b/CommonLibF4/include/F4SE/Impl/PCH.h
@@ -40,7 +40,6 @@ static_assert(
 	"wrap std::time_t instead");
 
 #pragma warning(push, 0)
-#include <boost/stl_interfaces/iterator_interface.hpp>
 #include <boost/stl_interfaces/sequence_container_interface.hpp>
 #include <fmt/format.h>
 #include <mmio/mmio.hpp>
@@ -208,31 +207,18 @@ namespace F4SE
 		scope_exit(EF) -> scope_exit<EF>;
 
 		template <class F>
-		class counted_function_iterator :
-			public boost::stl_interfaces::iterator_interface<
-				counted_function_iterator<F>,
-				std::input_iterator_tag,
-				std::remove_reference_t<decltype(std::declval<F>()())>>
+		class counted_function_iterator
 		{
-		private:
-			using super =
-				boost::stl_interfaces::iterator_interface<
-					counted_function_iterator<F>,
-					std::input_iterator_tag,
-					std::remove_reference_t<decltype(std::declval<F>()())>>;
-
 		public:
-			using difference_type = typename super::difference_type;
-			using value_type = typename super::value_type;
-			using pointer = typename super::pointer;
-			using reference = typename super::reference;
-			using iterator_category = typename super::iterator_category;
+			using difference_type = std::ptrdiff_t;
+			using value_type = std::remove_const_t<std::remove_reference_t<decltype(std::declval<F>()())>>;
+			using pointer = value_type*;
+			using reference = value_type&;
+			using iterator_category = std::input_iterator_tag;
 
 			counted_function_iterator() noexcept = default;
 
-			counted_function_iterator(
-				F a_fn,
-				std::size_t a_count) noexcept :
+			counted_function_iterator(F a_fn, std::size_t a_count) noexcept :
 				_fn(std::move(a_fn)),
 				_left(a_count)
 			{}
@@ -244,6 +230,11 @@ namespace F4SE
 				return (*_fn)();
 			}
 
+			[[nodiscard]] pointer operator->() const
+			{
+				return std::pointer_traits<pointer>::pointer_to(operator*());
+			}
+
 			[[nodiscard]] friend bool operator==(
 				const counted_function_iterator& a_lhs,
 				const counted_function_iterator& a_rhs) noexcept
@@ -251,12 +242,18 @@ namespace F4SE
 				return a_lhs._left == a_rhs._left;
 			}
 
-			using super::operator++;
-
-			void operator++() noexcept
+			counted_function_iterator& operator++() noexcept
 			{
 				assert(_left > 0);
 				_left -= 1;
+				return *this;
+			}
+
+			counted_function_iterator operator++(int) noexcept
+			{
+				counted_function_iterator tmp{ *this };
+				operator++();
+				return tmp;
 			}
 
 		private:

--- a/CommonLibF4/include/F4SE/Impl/PCH.h
+++ b/CommonLibF4/include/F4SE/Impl/PCH.h
@@ -41,7 +41,6 @@ static_assert(
 
 #pragma warning(push, 0)
 #include <boost/stl_interfaces/sequence_container_interface.hpp>
-#include <fmt/format.h>
 #include <mmio/mmio.hpp>
 #include <spdlog/spdlog.h>
 #pragma warning(pop)
@@ -576,7 +575,7 @@ namespace F4SE
 					fileview = fileview.substr(pos + off);
 				}
 
-				return fmt::format(FMT_STRING("{}({}): {}"), fileview, a_loc.line(), a_msg);
+				return std::format("{}({}): {}", fileview, a_loc.line(), a_msg);
 			}();
 
 			const auto caption = []() -> std::string {

--- a/CommonLibF4/include/F4SE/Logger.h
+++ b/CommonLibF4/include/F4SE/Logger.h
@@ -8,7 +8,7 @@
 		a_func() = delete;                                                \
                                                                           \
 		explicit a_func(                                                  \
-			fmt::format_string<Args...> a_fmt,                            \
+			spdlog::format_string_t<Args...> a_fmt,                       \
 			Args&&... a_args,                                             \
 			std::source_location a_loc = std::source_location::current()) \
 		{                                                                 \
@@ -24,7 +24,7 @@
 	};                                                                    \
                                                                           \
 	template <class... Args>                                              \
-	a_func(fmt::format_string<Args...>, Args&&...) -> a_func<Args...>;
+	a_func(spdlog::format_string_t<Args...>, Args&&...) -> a_func<Args...>;
 
 namespace F4SE::log
 {

--- a/CommonLibF4/include/F4SE/Version.h
+++ b/CommonLibF4/include/F4SE/Version.h
@@ -53,6 +53,7 @@ namespace F4SE
 	inline constexpr REL::Version RUNTIME_1_10_162{ 1, 10, 162, 0 };
 	inline constexpr REL::Version RUNTIME_1_10_163{ 1, 10, 163, 0 };
 	inline constexpr REL::Version RUNTIME_1_10_980{ 1, 10, 980, 0 };
+	inline constexpr REL::Version RUNTIME_1_10_984{ 1, 10, 984, 0 };
 
-	inline constexpr auto RUNTIME_LATEST = RUNTIME_1_10_980;
+	inline constexpr auto RUNTIME_LATEST = RUNTIME_1_10_984;
 }

--- a/CommonLibF4/include/RE/Bethesda/BSScript/NF_util/NativeFunctionBase.h
+++ b/CommonLibF4/include/RE/Bethesda/BSScript/NF_util/NativeFunctionBase.h
@@ -51,7 +51,7 @@ namespace RE
 					isLatent(a_isLatent)
 				{
 					for (std::size_t i = 0; i < descTable.paramCount; ++i) {
-						descTable.entries[i].first = fmt::format(FMT_STRING("param{}"), i + 1);
+						descTable.entries[i].first = std::format("param{}", i + 1);
 					}
 				}
 

--- a/CommonLibF4/include/RE/Bethesda/BSScriptUtil.h
+++ b/CommonLibF4/include/RE/Bethesda/BSScriptUtil.h
@@ -60,12 +60,8 @@ namespace RE::BSScript
 			if (!_proxy) {
 				const auto game = GameVM::GetSingleton();
 				const auto vm = game ? game->GetVM() : nullptr;
-				if (!vm ||
-					!vm->CreateStruct(name, _proxy) ||
-					!_proxy) {
-					F4SE::log::error(
-						FMT_STRING("failed to create structure of type \"{}\""),
-						name);
+				if (!vm || !vm->CreateStruct(name, _proxy) || !_proxy) {
+					F4SE::log::error("failed to create structure of type \"{}\"", name);
 					assert(false);
 				}
 			}
@@ -84,10 +80,7 @@ namespace RE::BSScript
 			}
 
 			if (!a_quiet) {
-				F4SE::log::warn(
-					FMT_STRING("failed to find var \"{}\" on structure \"{}\""),
-					a_name,
-					name);
+				F4SE::log::warn("failed to find var \"{}\" on structure \"{}\"", a_name, name);
 			}
 
 			return std::nullopt;
@@ -106,10 +99,7 @@ namespace RE::BSScript
 				}
 			}
 
-			F4SE::log::warn(
-				FMT_STRING("failed to pack var \"{}\" on structure \"{}\""),
-				a_name,
-				name);
+			F4SE::log::warn("failed to pack var \"{}\" on structure \"{}\"", a_name, name);
 			return false;
 		}
 
@@ -1229,10 +1219,7 @@ namespace RE::BSScript
 				std::move(a_func),
 				a_isLatent));
 		if (!success) {
-			F4SE::log::warn(
-				FMT_STRING("failed to register method \"{}\" on object \"{}\""),
-				a_function,
-				a_object);
+			F4SE::log::warn("failed to register method \"{}\" on object \"{}\"", a_function, a_object);
 		}
 
 		if (success && a_taskletCallable) {

--- a/CommonLibF4/include/RE/Bethesda/BSTBTree.h
+++ b/CommonLibF4/include/RE/Bethesda/BSTBTree.h
@@ -45,25 +45,14 @@ namespace RE
 
 	private:
 		template <class U>
-		class iterator_base :
-			public boost::stl_interfaces::iterator_interface<
-				iterator_base<U>,
-				std::forward_iterator_tag,
-				U>
+		class iterator_base
 		{
-		private:
-			using super =
-				boost::stl_interfaces::iterator_interface<
-					iterator_base<U>,
-					std::forward_iterator_tag,
-					U>;
-
 		public:
-			using difference_type = typename super::difference_type;
-			using value_type = typename super::value_type;
-			using pointer = typename super::pointer;
-			using reference = typename super::reference;
-			using iterator_category = typename super::iterator_category;
+			using difference_type = std::ptrdiff_t;
+			using value_type = std::remove_const_t<U>;
+			using pointer = value_type*;
+			using reference = value_type&;
+			using iterator_category = std::forward_iterator_tag;
 
 			iterator_base() noexcept = default;
 
@@ -116,15 +105,24 @@ namespace RE
 				return _cur->entries[_pos];
 			}
 
+			[[nodiscard]] pointer operator->() const noexcept
+			{
+				return std::pointer_traits<pointer>::pointer_to(operator*());
+			}
+
 			template <class V>
 			[[nodiscard]] bool operator==(const iterator_base<V>& a_rhs) const noexcept
 			{
 				return _cur == nullptr && a_rhs._cur == nullptr;
 			}
 
-			using super::operator++;
+			template <class V>
+			[[nodiscard]] bool operator!=(const iterator_base<V>& a_rhs) const noexcept
+			{
+				return !operator==(a_rhs);
+			}
 
-			void operator++() noexcept
+			iterator_base& operator++() noexcept
 			{
 				assert(_cur != nullptr);
 				if (++_pos >= _cur->usedEntries) {
@@ -136,6 +134,15 @@ namespace RE
 						push_level();
 					}
 				}
+
+				return *this;
+			}
+
+			iterator_base operator++(int) noexcept
+			{
+				iterator_base tmp{ *this };
+				operator++();
+				return tmp;
 			}
 
 		protected:

--- a/CommonLibF4/include/RE/Bethesda/BSTHashMap.h
+++ b/CommonLibF4/include/RE/Bethesda/BSTHashMap.h
@@ -115,25 +115,14 @@ namespace RE
 		};
 
 		template <class U>
-		class iterator_base :
-			public boost::stl_interfaces::iterator_interface<
-				iterator_base<U>,
-				std::forward_iterator_tag,
-				U>
+		class iterator_base
 		{
-		private:
-			using super =
-				boost::stl_interfaces::iterator_interface<
-					iterator_base<U>,
-					std::forward_iterator_tag,
-					U>;
-
 		public:
-			using difference_type = typename super::difference_type;
-			using value_type = typename super::value_type;
-			using pointer = typename super::pointer;
-			using reference = typename super::reference;
-			using iterator_category = typename super::iterator_category;
+			using difference_type = std::ptrdiff_t;
+			using value_type = std::remove_const_t<U>;
+			using pointer = value_type*;
+			using reference = value_type&;
+			using iterator_category = std::forward_iterator_tag;
 
 			iterator_base() = default;
 
@@ -163,11 +152,22 @@ namespace RE
 				return _first->value;
 			}
 
+			[[nodiscard]] pointer operator->() const noexcept
+			{
+				return std::pointer_traits<pointer>::pointer_to(operator*());
+			}
+
 			template <class V>
 			[[nodiscard]] bool operator==(const iterator_base<V>& a_rhs) const noexcept
 			{
 				assert(_last == a_rhs._last);
 				return _first == a_rhs._first;
+			}
+
+			template <class V>
+			[[nodiscard]] bool operator!=(const iterator_base<V>& a_rhs) const noexcept
+			{
+				return !operator==(a_rhs);
 			}
 
 			iterator_base& operator++() noexcept
@@ -176,7 +176,12 @@ namespace RE
 				return *this;
 			}
 
-			using super::operator++;
+			iterator_base operator++(int) noexcept
+			{
+				iterator_base tmp{ *this };
+				operator++();
+				return tmp;
+			}
 
 		protected:
 			friend class BSTScatterTable;

--- a/CommonLibF4/include/RE/Bethesda/BSTList.h
+++ b/CommonLibF4/include/RE/Bethesda/BSTList.h
@@ -28,25 +28,14 @@ namespace RE
 		};
 
 		template <class U>
-		class iterator_base :
-			public boost::stl_interfaces::iterator_interface<
-				iterator_base<U>,
-				std::forward_iterator_tag,
-				U>
+		class iterator_base
 		{
-		private:
-			using super =
-				boost::stl_interfaces::iterator_interface<
-					iterator_base<U>,
-					std::forward_iterator_tag,
-					U>;
-
 		public:
-			using difference_type = typename super::difference_type;
-			using value_type = typename super::value_type;
-			using pointer = typename super::pointer;
-			using reference = typename super::reference;
-			using iterator_category = typename super::iterator_category;
+			using difference_type = std::ptrdiff_t;
+			using value_type = std::remove_const_t<U>;
+			using pointer = value_type*;
+			using reference = value_type&;
+			using iterator_category = std::forward_iterator_tag;
 
 			iterator_base() noexcept = default;
 			iterator_base(const iterator_base&) noexcept = default;
@@ -86,6 +75,24 @@ namespace RE
 				return get()->value;
 			}
 
+			[[nodiscard]] pointer operator->() noexcept
+			{
+				return std::pointer_traits<pointer>::pointer_to(operator*());
+			}
+
+			template <class V>
+			[[nodiscard]] bool operator==(const iterator_base<V>& a_rhs) const noexcept
+			{
+				assert(_proxy == a_rhs._proxy);
+				return _cur == a_rhs._cur;
+			}
+
+			template <class V>
+			[[nodiscard]] bool operator!=(const iterator_base<V>& a_rhs) const noexcept
+			{
+				return !operator==(a_rhs);
+			}
+
 			iterator_base& operator++() noexcept
 			{
 				if (_cur) {
@@ -97,19 +104,11 @@ namespace RE
 				return *this;
 			}
 
-			using super::operator++;
-
-			template <class V>
-			[[nodiscard]] bool operator==(const iterator_base<V>& a_rhs) noexcept
+			iterator_base operator++(int) noexcept
 			{
-				assert(_proxy == a_rhs._proxy);
-				return _cur == a_rhs._cur;
-			}
-
-			template <class V>
-			[[nodiscard]] bool operator!=(const iterator_base<V>& a_rhs) noexcept
-			{
-				return !(*this == a_rhs);
+				iterator_base tmp{ *this };
+				operator++();
+				return tmp;
 			}
 
 		protected:

--- a/CommonLibF4/include/RE/Bethesda/BSTObjectArena.h
+++ b/CommonLibF4/include/RE/Bethesda/BSTObjectArena.h
@@ -57,25 +57,14 @@ namespace RE
 
 	private:
 		template <class U>
-		class iterator_base :
-			public boost::stl_interfaces::iterator_interface<
-				iterator_base<U>,
-				std::forward_iterator_tag,
-				U>
+		class iterator_base
 		{
-		private:
-			using super =
-				boost::stl_interfaces::iterator_interface<
-					iterator_base<U>,
-					std::forward_iterator_tag,
-					U>;
-
 		public:
-			using difference_type = typename super::difference_type;
-			using value_type = typename super::value_type;
-			using pointer = typename super::pointer;
-			using reference = typename super::reference;
-			using iterator_category = typename super::iterator_category;
+			using difference_type = std::ptrdiff_t;
+			using value_type = std::remove_const_t<U>;
+			using pointer = value_type*;
+			using reference = value_type&;
+			using iterator_category = std::forward_iterator_tag;
 
 			iterator_base() noexcept = default;
 
@@ -105,6 +94,11 @@ namespace RE
 				return *std::launder(reinterpret_cast<pointer>(_first));
 			}
 
+			[[nodiscard]] pointer operator->() const noexcept
+			{
+				return std::pointer_traits<pointer>::pointer_to(operator*());
+			}
+
 			template <class V>
 			[[nodiscard]] bool operator==(const iterator_base<V>& a_rhs) const noexcept
 			{
@@ -117,9 +111,13 @@ namespace RE
 				}
 			}
 
-			using super::operator++;
+			template <class V>
+			[[nodiscard]] bool operator!=(const iterator_base<V>& a_rhs) const noexcept
+			{
+				return !operator==(a_rhs);
+			}
 
-			void operator++() noexcept
+			iterator_base& operator++() noexcept
 			{
 				assert(good());
 				_first += sizeof(value_type);
@@ -127,6 +125,14 @@ namespace RE
 					_proxy = _proxy->next;
 					_first = _proxy->begin();
 				}
+				return *this;
+			}
+
+			iterator_base operator++(int) noexcept
+			{
+				iterator_base tmp{ *this };
+				operator++();
+				return tmp;
 			}
 
 		protected:

--- a/CommonLibF4/include/RE/NetImmerse/NiTArray.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiTArray.h
@@ -17,25 +17,14 @@ namespace RE
 		using const_pointer = const value_type*;
 
 		template <class U>
-		class iterator_base :
-			public boost::stl_interfaces::iterator_interface<
-				iterator_base<U>,
-				std::bidirectional_iterator_tag,
-				U>
+		class iterator_base
 		{
-		private:
-			using super =
-				boost::stl_interfaces::iterator_interface<
-					iterator_base<U>,
-					std::bidirectional_iterator_tag,
-					U>;
-
 		public:
-			using difference_type = typename super::difference_type;
-			using value_type = typename super::value_type;
-			using pointer = typename super::pointer;
-			using reference = typename super::reference;
-			using iterator_category = typename super::iterator_category;
+			using difference_type = std::ptrdiff_t;
+			using value_type = std::remove_const_t<U>;
+			using pointer = value_type*;
+			using reference = value_type&;
+			using iterator_category = std::bidirectional_iterator_tag;
 
 			~iterator_base() noexcept = default;
 			iterator_base() noexcept = default;
@@ -66,6 +55,12 @@ namespace RE
 				return *_pos;
 			}
 
+
+			[[nodiscard]] pointer operator->() const noexcept
+			{
+				return std::pointer_traits<pointer>::pointer_to(operator*());
+			}
+
 			template <class V>
 			[[nodiscard]] bool operator==(const iterator_base<V>& a_rhs) const noexcept
 			{
@@ -74,24 +69,42 @@ namespace RE
 				return _pos == a_rhs._pos;
 			}
 
-			using super::operator++;
+			template <class V>
+			[[nodiscard]] bool operator!=(const iterator_base<V>& a_rhs) const noexcept
+			{
+				return !operator==(a_rhs);
+			}
 
-			void operator++() noexcept
+			iterator_base& operator++() noexcept
 			{
 				assert(validate());
 				do {
 					++_pos;
 				} while (_pos < _tail && !slot_filled());
+				return *this;
 			}
 
-			using super::operator--;
+			iterator_base operator++(int) noexcept
+			{
+				iterator_base tmp{ *this };
+				operator++();
+				return tmp;
+			}
 
-			void operator--() noexcept
+			iterator_base& operator--() noexcept
 			{
 				assert(validate());
 				do {
 					--_pos;
 				} while (_head <= _pos && !slot_filled());
+				return *this;
+			}
+
+			iterator_base operator--(int) noexcept
+			{
+				iterator_base tmp{ *this };
+				operator--();
+				return tmp;
 			}
 
 		private:

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -622,20 +622,20 @@ namespace REL
 		void load()
 		{
 			const auto version = Module::get().version();
-			const auto path = fmt::format(
+			const auto path = std::format(
 				"Data/F4SE/Plugins/version-{}.bin",
 				version.string());
 			if (!_mmap.open(path)) {
-				stl::report_and_fail(fmt::format("failed to open: {}", path));
+				stl::report_and_fail(std::format("failed to open: {}", path));
 			}
 			if (version == REL::Version(1, 10, 980)) {
 				const auto sha = detail::sha512({ _mmap });
 				if (!sha) {
-					stl::report_and_fail(fmt::format("failed to hash: {}", path));
+					stl::report_and_fail(std::format("failed to hash: {}", path));
 				}
 				// Address bins are expected to be pre-sorted. This bin was released without being sorted, and will cause lookups to randomly fail.
 				if (*sha == "2AD60B95388F1B6E77A6F86F17BEB51D043CF95A341E91ECB2E911A393E45FE8156D585D2562F7B14434483D6E6652E2373B91589013507CABAE596C26A343F1"sv) {
-					stl::report_and_fail(fmt::format(
+					stl::report_and_fail(std::format(
 						"The address bin you are using ({}) is corrupted. "
 						"Please go to the Nexus page for Address Library and redownload the file corresponding to version {}.{}.{}.{}",
 						path,

--- a/CommonLibF4/src/F4SE/API.cpp
+++ b/CommonLibF4/src/F4SE/API.cpp
@@ -109,9 +109,7 @@ namespace F4SE
 			}
 		}
 
-		log::warn(
-			FMT_STRING("failed to get plugin info for {}"),
-			a_plugin);
+		log::warn("failed to get plugin info for {}", a_plugin);
 		return std::nullopt;
 	}
 

--- a/CommonLibF4/src/F4SE/Trampoline.cpp
+++ b/CommonLibF4/src/F4SE/Trampoline.cpp
@@ -81,7 +81,7 @@ namespace F4SE
 		::MEMORY_BASIC_INFORMATION mbi;
 		do {
 			if (!::VirtualQuery(reinterpret_cast<void*>(min), std::addressof(mbi), sizeof(mbi))) {
-				log::error(FMT_STRING("VirtualQuery failed with code: 0x{:08X}"), ::GetLastError());
+				log::error("VirtualQuery failed with code: 0x{:08X}", ::GetLastError());
 				return nullptr;
 			}
 
@@ -97,7 +97,7 @@ namespace F4SE
 					if (mem) {
 						return mem;
 					} else {
-						log::warn(FMT_STRING("VirtualAlloc failed with code: 0x{:08X}"), ::GetLastError());
+						log::warn("VirtualAlloc failed with code: 0x{:08X}", ::GetLastError());
 					}
 				}
 			}
@@ -108,14 +108,7 @@ namespace F4SE
 
 	void Trampoline::log_stats() const
 	{
-		auto pct = (static_cast<double>(_size) /
-					   static_cast<double>(_capacity)) *
-		           100.0;
-		log::debug(
-			FMT_STRING("{} => {}B / {}B ({:05.2f}%)"),
-			_name,
-			_size,
-			_capacity,
-			pct);
+		auto pct = (static_cast<double>(_size) / static_cast<double>(_capacity)) * 100.0;
+		log::debug("{} => {}B / {}B ({:05.2f}%)", _name, _size, _capacity, pct);
 	}
 }

--- a/CommonLibF4/src/REL/Relocation.cpp
+++ b/CommonLibF4/src/REL/Relocation.cpp
@@ -124,7 +124,7 @@ namespace REL
 			std::string result;
 			result.reserve(buffer.size() * 2);
 			for (const auto byte : buffer) {
-				result += fmt::format("{:02X}", byte);
+				result += std::format("{:02X}", byte);
 			}
 
 			return { std::move(result) };

--- a/CommonLibF4/vcpkg.json
+++ b/CommonLibF4/vcpkg.json
@@ -7,7 +7,6 @@
   "supports": "windows & x64",
   "dependencies": [
     "boost-stl-interfaces",
-    "fmt",
     "rsm-mmio",
     "spdlog"
   ]

--- a/ExampleProject/CMakeLists.txt
+++ b/ExampleProject/CMakeLists.txt
@@ -78,7 +78,6 @@ if (NOT TARGET CommonLibF4)
 	add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../CommonLibF4" CommonLibF4)
 endif ()
 
-find_package(fmt REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 
 # ---- Add source files ----
@@ -128,7 +127,6 @@ target_link_libraries(
 	${PROJECT_NAME}
 	PRIVATE
 		CommonLibF4::CommonLibF4
-		fmt::fmt
 		spdlog::spdlog
 )
 

--- a/ExampleProject/src/main.cpp
+++ b/ExampleProject/src/main.cpp
@@ -8,7 +8,7 @@ extern "C" DLLEXPORT bool F4SEAPI F4SEPlugin_Query(const F4SE::QueryInterface* a
 		return false;
 	}
 
-	*path /= fmt::format(FMT_STRING("{}.log"), Version::PROJECT);
+	*path /= std::format("{}.log", Version::PROJECT);
 	auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(path->string(), true);
 #endif
 

--- a/ExampleProject/vcpkg.json
+++ b/ExampleProject/vcpkg.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "dependencies": [
     "boost-stl-interfaces",
-    "fmt",
     "rsm-mmio",
     "spdlog"
   ]

--- a/F4SEStub/loader/CMakeLists.txt
+++ b/F4SEStub/loader/CMakeLists.txt
@@ -12,7 +12,6 @@ add_project(
 )
 
 find_package(args REQUIRED CONFIG)
-find_package(fmt REQUIRED CONFIG)
 find_package(frozen REQUIRED CONFIG)
 find_package(nowide REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
@@ -21,7 +20,6 @@ find_package(xbyak REQUIRED CONFIG)
 target_link_libraries(
 	"${PROJECT_NAME}"
 	PRIVATE
-		fmt::fmt
 		frozen::frozen
 		nowide::nowide
 		spdlog::spdlog

--- a/F4SEStub/loader/CMakeLists.txt
+++ b/F4SEStub/loader/CMakeLists.txt
@@ -12,14 +12,12 @@ add_project(
 )
 
 find_package(args REQUIRED CONFIG)
-find_package(nowide REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 find_package(xbyak REQUIRED CONFIG)
 
 target_link_libraries(
 	"${PROJECT_NAME}"
 	PRIVATE
-		nowide::nowide
 		spdlog::spdlog
 		taywee::args
 		Version.lib

--- a/F4SEStub/loader/CMakeLists.txt
+++ b/F4SEStub/loader/CMakeLists.txt
@@ -12,7 +12,6 @@ add_project(
 )
 
 find_package(args REQUIRED CONFIG)
-find_package(frozen REQUIRED CONFIG)
 find_package(nowide REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 find_package(xbyak REQUIRED CONFIG)
@@ -20,7 +19,6 @@ find_package(xbyak REQUIRED CONFIG)
 target_link_libraries(
 	"${PROJECT_NAME}"
 	PRIVATE
-		frozen::frozen
 		nowide::nowide
 		spdlog::spdlog
 		taywee::args

--- a/F4SEStub/loader/README.md
+++ b/F4SEStub/loader/README.md
@@ -1,6 +1,5 @@
 ## Build Dependencies
 * [args](https://github.com/Taywee/args)
-* [Frozen](https://github.com/serge-sans-paille/frozen)
 * [nowide](https://github.com/boostorg/nowide/tree/standalone)
 * [spdlog](https://github.com/gabime/spdlog)
 * [Xbyak](https://github.com/herumi/xbyak)

--- a/F4SEStub/loader/README.md
+++ b/F4SEStub/loader/README.md
@@ -1,6 +1,5 @@
 ## Build Dependencies
 * [args](https://github.com/Taywee/args)
-* [fmt](https://github.com/fmtlib/fmt)
 * [Frozen](https://github.com/serge-sans-paille/frozen)
 * [nowide](https://github.com/boostorg/nowide/tree/standalone)
 * [spdlog](https://github.com/gabime/spdlog)

--- a/F4SEStub/loader/README.md
+++ b/F4SEStub/loader/README.md
@@ -1,5 +1,4 @@
 ## Build Dependencies
 * [args](https://github.com/Taywee/args)
-* [nowide](https://github.com/boostorg/nowide/tree/standalone)
 * [spdlog](https://github.com/gabime/spdlog)
 * [Xbyak](https://github.com/herumi/xbyak)

--- a/F4SEStub/loader/src/main.cpp
+++ b/F4SEStub/loader/src/main.cpp
@@ -179,7 +179,7 @@ namespace cli
 		{
 			bool operator()(const std::string& a_name, const std::string& a_value, DWORD& a_dst)
 			{
-				constexpr frozen::map<std::string_view, ::DWORD, 6> map = {
+				static const std::map<std::string_view, ::DWORD> map = {
 					std::make_pair("realtime"sv, REALTIME_PRIORITY_CLASS),
 					std::make_pair("high"sv, HIGH_PRIORITY_CLASS),
 					std::make_pair("above_normal"sv, ABOVE_NORMAL_PRIORITY_CLASS),
@@ -199,11 +199,7 @@ namespace cli
 					a_dst = it->second;
 					return true;
 				} else {
-					throw args::ParseError(
-						std::format(
-							"Argument \'{}\' received invalid value type \'{}\'",
-							a_name,
-							a_value));
+					throw args::ParseError(std::format("Argument \'{}\' received invalid value type \'{}\'", a_name, a_value));
 				}
 			}
 		};

--- a/F4SEStub/loader/src/main.cpp
+++ b/F4SEStub/loader/src/main.cpp
@@ -82,18 +82,62 @@ namespace win32
 
 namespace unicode
 {
-	using nowide::cerr;
-	using nowide::narrow;
-	using nowide::widen;
+	[[nodiscard]] std::string narrow(const wchar_t* a_src, std::size_t a_srcLength)
+	{
+		const auto cvt = [&](char* a_dst, std::size_t a_dstLength) {
+			return ::WideCharToMultiByte(
+				CP_UTF8,
+				0,
+				a_src,
+				static_cast<int>(a_srcLength),
+				a_dst,
+				static_cast<int>(a_dstLength),
+				nullptr,
+				nullptr);
+		};
+
+		const auto len = cvt(nullptr, 0);
+		if (len == 0)
+			return "";
+
+		std::string out(len, '\0');
+		if (cvt(out.data(), out.length()) == 0)
+			return "";
+
+		return out;
+	}
 
 	[[nodiscard]] std::string narrow(std::wstring_view a_str)
 	{
-		return nowide::narrow(a_str.data(), a_str.size());
+		return narrow(a_str.data(), a_str.length());
+	}
+
+	[[nodiscard]] std::wstring widen(const char* a_src, std::size_t a_srcLength)
+	{
+		const auto cvt = [&](wchar_t* a_dst, std::size_t a_dstLength) {
+			return ::MultiByteToWideChar(
+				CP_UTF8,
+				0,
+				a_src,
+				static_cast<int>(a_srcLength),
+				a_dst,
+				static_cast<int>(a_dstLength));
+		};
+
+		const auto len = cvt(nullptr, 0);
+		if (len == 0)
+			return L"";
+
+		std::wstring out(len, '\0');
+		if (cvt(out.data(), out.length()) == 0)
+			return L"";
+
+		return out;
 	}
 
 	[[nodiscard]] std::wstring widen(std::string_view a_str)
 	{
-		return nowide::widen(a_str.data(), a_str.size());
+		return widen(a_str.data(), a_str.length());
 	}
 }
 
@@ -975,7 +1019,7 @@ void do_main(std::span<const wchar_t*> a_args)
 int wmain(int a_argc, wchar_t* a_argv[])
 {
 	const auto cerr = [](std::string_view a_err) {
-		unicode::cerr
+		std::cerr
 			<< "failed to initialize log with error:\n"
 			<< "\t" << a_err << '\n';
 	};

--- a/F4SEStub/loader/src/main.cpp
+++ b/F4SEStub/loader/src/main.cpp
@@ -1,7 +1,3 @@
-template <>
-struct fmt::formatter<args::ArgumentParser> : fmt::ostream_formatter
-{};
-
 namespace stl
 {
 	template <class EF>                                    //
@@ -80,12 +76,7 @@ namespace win32
 {
 	[[noreturn]] void error(std::string_view a_error)
 	{
-		throw std::runtime_error{
-			fmt::format(
-				"{:08X}: {}",
-				::GetLastError(),
-				a_error)
-		};
+		throw std::runtime_error{ std::format("{:08X}: {}", ::GetLastError(), a_error) };
 	}
 }
 
@@ -209,7 +200,7 @@ namespace cli
 					return true;
 				} else {
 					throw args::ParseError(
-						fmt::format(
+						std::format(
 							"Argument \'{}\' received invalid value type \'{}\'",
 							a_name,
 							a_value));
@@ -268,12 +259,12 @@ namespace cli
 			const auto args = detail::do_parse(a_args);
 			p.ParseArgs(args.begin(), args.end());
 		} catch (const args::Help&) {
-			spdlog::trace(p);
+			spdlog::trace(p.Help());
 			return std::nullopt;
 		} catch (const args::ParseError& a_err) {
 			spdlog::error(a_err.what());
 			spdlog::trace("");
-			spdlog::trace(p);
+			spdlog::trace(p.Help());
 			return std::nullopt;
 		}
 
@@ -853,7 +844,7 @@ void augment_environment(
 			return *a_options.altdll;
 		} else {
 			const auto version = win32::get_file_version(exe);
-			return fmt::format(
+			return std::format(
 				"{}_{}_{}_{}.dll",
 				(a_options.editor ?
 						"f4se_editor"s :
@@ -866,7 +857,7 @@ void augment_environment(
 
 	const auto error = [](std::string_view a_file) {
 		throw std::runtime_error(
-			fmt::format(
+			std::format(
 				"file does not exist: {}",
 				a_file));
 	};

--- a/F4SEStub/loader/src/pch.h
+++ b/F4SEStub/loader/src/pch.h
@@ -53,6 +53,7 @@
 #include <cstring>
 #include <filesystem>
 #include <format>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <numeric>
@@ -67,8 +68,6 @@
 
 #pragma warning(push, 0)
 #include <args.hxx>
-#include <nowide/convert.hpp>
-#include <nowide/iostream.hpp>
 #include <spdlog/spdlog.h>
 
 #include <Windows.h>

--- a/F4SEStub/loader/src/pch.h
+++ b/F4SEStub/loader/src/pch.h
@@ -52,6 +52,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <format>
 #include <map>
 #include <memory>
 #include <numeric>
@@ -66,8 +67,6 @@
 
 #pragma warning(push, 0)
 #include <args.hxx>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <frozen/map.h>
 #include <nowide/convert.hpp>
 #include <nowide/iostream.hpp>

--- a/F4SEStub/loader/src/pch.h
+++ b/F4SEStub/loader/src/pch.h
@@ -67,7 +67,6 @@
 
 #pragma warning(push, 0)
 #include <args.hxx>
-#include <frozen/map.h>
 #include <nowide/convert.hpp>
 #include <nowide/iostream.hpp>
 #include <spdlog/spdlog.h>

--- a/F4SEStub/steam_loader/CMakeLists.txt
+++ b/F4SEStub/steam_loader/CMakeLists.txt
@@ -12,13 +12,11 @@ add_project(
 		"src/PCH.h"
 )
 
-find_package(nowide REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 
 target_link_libraries(
 	${PROJECT_NAME}
 	PRIVATE
-		nowide::nowide
 		spdlog::spdlog
 )
 

--- a/F4SEStub/steam_loader/CMakeLists.txt
+++ b/F4SEStub/steam_loader/CMakeLists.txt
@@ -12,14 +12,12 @@ add_project(
 		"src/PCH.h"
 )
 
-find_package(fmt REQUIRED CONFIG)
 find_package(nowide REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 
 target_link_libraries(
 	${PROJECT_NAME}
 	PRIVATE
-		fmt::fmt
 		nowide::nowide
 		spdlog::spdlog
 )

--- a/F4SEStub/steam_loader/README.md
+++ b/F4SEStub/steam_loader/README.md
@@ -1,4 +1,3 @@
 ## Build Dependencies
-* [fmt](https://github.com/fmtlib/fmt)
 * [nowide](https://github.com/boostorg/nowide/tree/standalone)
 * [spdlog](https://github.com/gabime/spdlog)

--- a/F4SEStub/steam_loader/README.md
+++ b/F4SEStub/steam_loader/README.md
@@ -1,3 +1,2 @@
 ## Build Dependencies
-* [nowide](https://github.com/boostorg/nowide/tree/standalone)
 * [spdlog](https://github.com/gabime/spdlog)

--- a/F4SEStub/steam_loader/src/main.cpp
+++ b/F4SEStub/steam_loader/src/main.cpp
@@ -88,12 +88,7 @@ namespace win32
 	{
 		[[noreturn]] void error(std::string_view a_error)
 		{
-			throw std::runtime_error{
-				fmt::format(
-					FMT_STRING("{:08X}: {}"),
-					::GetLastError(),
-					a_error)
-			};
+			throw std::runtime_error{ std::format("{:08X}: {}", ::GetLastError(), a_error) };
 		}
 	}
 
@@ -243,11 +238,9 @@ namespace util
 	}
 
 	template <class... Args>
-	[[noreturn]] void error(fmt::format_string<Args...> a_fmt, Args&&... a_args)
+	[[noreturn]] void error(std::format_string<Args...> a_fmt, Args&&... a_args)
 	{
-		throw std::runtime_error{
-			fmt::format(a_fmt, std::forward<Args>(a_args)...)
-		};
+		throw std::runtime_error{ std::format(a_fmt, std::forward<Args>(a_args)...) };
 	}
 
 	void safe_write(

--- a/F4SEStub/steam_loader/src/pch.h
+++ b/F4SEStub/steam_loader/src/pch.h
@@ -22,7 +22,7 @@
 #define NOGDI
 #define NOKERNEL
 //#define NOUSER
-#define NONLS
+//#define NONLS
 #define NOMB
 #define NOMEMMGR
 #define NOMETAFILE
@@ -48,6 +48,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <span>
@@ -58,8 +59,6 @@
 #include <utility>
 
 #pragma warning(push)
-#include <nowide/convert.hpp>
-#include <nowide/iostream.hpp>
 #include <spdlog/spdlog.h>
 
 #include <Windows.h>

--- a/F4SEStub/steam_loader/src/pch.h
+++ b/F4SEStub/steam_loader/src/pch.h
@@ -58,7 +58,6 @@
 #include <utility>
 
 #pragma warning(push)
-#include <fmt/format.h>
 #include <nowide/convert.hpp>
 #include <nowide/iostream.hpp>
 #include <spdlog/spdlog.h>

--- a/RTTIDump/CMakeLists.txt
+++ b/RTTIDump/CMakeLists.txt
@@ -17,7 +17,6 @@ if(NOT TARGET CommonLibF4)
 	add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../CommonLibF4" CommonLibF4)
 endif()
 
-find_package(robin_hood REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 find_package(srell MODULE REQUIRED)
 
@@ -26,7 +25,6 @@ target_link_libraries(
 	PUBLIC
 		CommonLibF4::CommonLibF4
 		Dbghelp.lib
-		robin_hood::robin_hood
 		spdlog::spdlog
 		srell::srell
 )

--- a/RTTIDump/README.md
+++ b/RTTIDump/README.md
@@ -1,5 +1,4 @@
 ## Build Dependencies
 * [CommonLibF4](https://github.com/Ryan-rsm-McKenzie/CommonLibF4)
-* [robin-hood-hashing](https://github.com/martinus/robin-hood-hashing)
 * [spdlog](https://github.com/gabime/spdlog)
 * [SRELL](https://www.akenotsuki.com/misc/srell/en/)

--- a/RTTIDump/src/PCH.h
+++ b/RTTIDump/src/PCH.h
@@ -12,10 +12,10 @@
 #include <memory>
 #include <span>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include <robin_hood.h>
 #include <srell.hpp>
 
 #ifdef NDEBUG

--- a/RTTIDump/src/main.cpp
+++ b/RTTIDump/src/main.cpp
@@ -315,7 +315,7 @@ void dump_nirtti()
 		2704769,  // bhkWorld
 		2704838,  // bhkWorldM
 	};
-	robin_hood::unordered_flat_set<std::uintptr_t> results;
+	std::unordered_set<std::uintptr_t> results;
 	results.reserve(seeds.size());
 	for (const auto& seed : seeds) {
 		results.insert(REL::ID(seed).address());

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,21 +13,13 @@ add_project(
 		"src/pch.h"
 )
 
-find_package(Boost MODULE REQUIRED)
 find_package(Catch2 REQUIRED CONFIG)
 
 include(Catch)
 catch_discover_tests("${PROJECT_NAME}")
 
-target_compile_definitions(
-	"${PROJECT_NAME}"
-	PRIVATE
-		BOOST_STL_INTERFACES_DISABLE_CONCEPTS
-)
-
 target_link_libraries(
 	"${PROJECT_NAME}"
 	PRIVATE
-		Boost::headers
 		Catch2::Catch2WithMain
 )

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,5 +1,3 @@
 ## Build Dependencies
-* [Boost](https://www.boost.org/)
-	* Stl_interfaces
 * [Catch2](https://github.com/catchorg/Catch2)
 * [CommonLibF4](https://github.com/Ryan-rsm-McKenzie/CommonLibF4)

--- a/Tests/src/pch.h
+++ b/Tests/src/pch.h
@@ -93,8 +93,4 @@
 #include <vector>
 #include <version>
 
-#pragma warning(push)
-#include <boost/stl_interfaces/iterator_interface.hpp>
-#pragma warning(pop)
-
 using namespace std::literals;

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -155,6 +155,8 @@ macro(add_project)
 				"/Zi"	# Debug Information Format
 
 				"/permissive-"	# Standards conformance
+			PUBLIC
+				"/wd4702" # unreachable code
 		)
 
 		target_link_options(

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
     "args",
     "boost-stl-interfaces",
     "catch2",
-    "fmt",
     "frozen",
     "nowide",
     "rsm-mmio",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
     "args",
     "boost-stl-interfaces",
     "catch2",
-    "frozen",
     "nowide",
     "rsm-mmio",
     "spdlog",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,6 @@
     "fmt",
     "frozen",
     "nowide",
-    "robin-hood-hashing",
     "rsm-mmio",
     "spdlog",
     "srell",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
     "args",
     "boost-stl-interfaces",
     "catch2",
-    "nowide",
     "rsm-mmio",
     "spdlog",
     "srell",


### PR DESCRIPTION
- remove `robin-hood-hashing`
  - performance difference is negligible compared to `std::unordered_map` and not worth the extra dependency
- remove `boost`'s `stl_interfaces::iterator_interface`
  - additionally, only `BSTArray` uses `stl_interfaces::sequence_container_interface` but it's much larger than the others and I'm unsure how to go about removing it properly; if someone else can do it then we can remove boost entirely.
- remove `fmt`
  - should be backwards compatible with projects still using fmt
- remove `frozen`
  - the need for a highly performant constexpr `map` class isn't necessary here given it's not on a hot path
- remove `nowide`
- silence external warning caused by `xbyak`
- add runtime version `1.10.984.0`

one thing to consider is whether we should remove the `F4SEStub` projects given ryan never finished them and are unused anywhere. they are a bit of a maintenance burden trying to keep them building when making changes like this. 