### PR TITLE
feat: add `xmake` support and a default logger

### DIFF
--- a/AddressLibDecoder/xmake.lua
+++ b/AddressLibDecoder/xmake.lua
@@ -1,0 +1,12 @@
+target("addresslibdecoder")
+    -- set build by default
+    set_default(false)
+
+    -- set build group
+    set_group("tool")
+    
+    -- add packages
+    add_packages("rsm-mmio")
+
+    -- add source files
+    add_files("src/**.cpp")

--- a/AddressLibGen/xmake.lua
+++ b/AddressLibGen/xmake.lua
@@ -1,0 +1,9 @@
+target("addresslibgen")
+    -- set build by default
+    set_default(false)
+
+    -- set build group
+    set_group("tool")
+
+    -- add source files
+    add_files("src/**.cpp")

--- a/CommonLibF4/include/F4SE/API.h
+++ b/CommonLibF4/include/F4SE/API.h
@@ -18,12 +18,17 @@ namespace F4SE
 
 	class Trampoline;
 
-	void Init(const LoadInterface* a_intfc) noexcept;
+	void Init(const LoadInterface* a_intfc, bool a_log = true) noexcept;
+
+	[[nodiscard]] std::string_view GetPluginName() noexcept;
+	[[nodiscard]] std::string_view GetPluginAuthor() noexcept;
+	[[nodiscard]] REL::Version GetPluginVersion() noexcept;
 
 	[[nodiscard]] REL::Version GetF4SEVersion() noexcept;
 	[[nodiscard]] PluginHandle GetPluginHandle() noexcept;
 	[[nodiscard]] std::uint32_t GetReleaseIndex() noexcept;
-	[[nodiscard]] std::optional<PluginInfo> GetPluginInfo(stl::zstring a_plugin) noexcept;
+	[[nodiscard]] std::optional<PluginInfo> GetPluginInfo(std::string_view a_plugin) noexcept;
+	[[nodiscard]] std::string_view GetSaveFolderName() noexcept;
 
 	[[nodiscard]] const MessagingInterface* GetMessagingInterface() noexcept;
 	[[nodiscard]] const ScaleformInterface* GetScaleformInterface() noexcept;

--- a/CommonLibF4/include/F4SE/Impl/PCH.h
+++ b/CommonLibF4/include/F4SE/Impl/PCH.h
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <functional>
 #include <initializer_list>
+#include <intrin.h>
 #include <iterator>
 #include <limits>
 #include <map>

--- a/CommonLibF4/include/F4SE/Interfaces.h
+++ b/CommonLibF4/include/F4SE/Interfaces.h
@@ -38,6 +38,7 @@ namespace F4SE
 			std::uint32_t(F4SEAPI* GetPluginHandle)(void);
 			std::uint32_t(F4SEAPI* GetReleaseIndex)(void);
 			const void*(F4SEAPI* GetPluginInfo)(const char*);  // 0.6.22+
+			const char*(F4SEAPI* GetSaveFolderName)(void);  // 0.7.1+
 		};
 
 		struct F4SEMessagingInterface
@@ -125,6 +126,7 @@ namespace F4SE
 		[[nodiscard]] REL::Version F4SEVersion() const noexcept { return MakeVersion(GetProxy().f4seVersion); }
 		[[nodiscard]] PluginHandle GetPluginHandle() const { return GetProxy().GetPluginHandle(); }
 		[[nodiscard]] std::uint32_t GetReleaseIndex() const { return GetProxy().GetReleaseIndex(); }
+		[[nodiscard]] std::string_view GetSaveFolderName() const { return GetProxy().GetSaveFolderName(); }
 		[[nodiscard]] bool IsEditor() const noexcept { return GetProxy().isEditor != 0; }
 		[[nodiscard]] REL::Version RuntimeVersion() const noexcept { return MakeVersion(GetProxy().runtimeVersion); }
 	};
@@ -478,3 +480,7 @@ namespace F4SE
 	static_assert(offsetof(PluginVersionData, reserved) == 0x25C);
 	static_assert(sizeof(PluginVersionData) == 0x45C);
 }
+
+#define F4SE_EXPORT extern "C" [[maybe_unused]] __declspec(dllexport)
+#define F4SE_PLUGIN_PRELOAD(...) F4SE_EXPORT bool F4SEPlugin_Preload(__VA_ARGS__)
+#define F4SE_PLUGIN_LOAD(...) F4SE_EXPORT bool F4SEPlugin_Load(__VA_ARGS__)

--- a/CommonLibF4/include/F4SE/Logger.h
+++ b/CommonLibF4/include/F4SE/Logger.h
@@ -36,6 +36,8 @@ namespace F4SE::log
 	F4SE_MAKE_SOURCE_LOGGER(critical, critical);
 
 	[[nodiscard]] std::optional<std::filesystem::path> log_directory();
+
+	void init();
 }
 
 #undef F4SE_MAKE_SOURCE_LOGGER

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -793,6 +793,16 @@ namespace REL
 	};
 }
 
+template <class CharT>
+struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
+{
+	template <class FormatContext>
+	constexpr auto format(const REL::Version& a_version, FormatContext& a_ctx) const
+	{
+		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+	}
+};
+
 #undef REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE
 #undef REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE_HELPER
 #undef REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE_HELPER_IMPL

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -280,25 +280,25 @@ namespace REL
 
 		[[nodiscard]] constexpr value_type build() const noexcept { return _impl[3]; }
 
-		[[nodiscard]] std::string string() const
+		[[nodiscard]] constexpr std::string string(const std::string_view a_separator = "."sv) const
 		{
 			std::string result;
 			for (auto&& ver : _impl) {
 				result += std::to_string(ver);
-				result += '-';
+				result.append(a_separator.data(), a_separator.size());
 			}
-			result.pop_back();
+			result.erase(result.size() - a_separator.size(), a_separator.size());
 			return result;
 		}
 
-		[[nodiscard]] std::wstring wstring() const
+		[[nodiscard]] constexpr std::wstring wstring(const std::wstring_view a_separator = L"."sv) const
 		{
 			std::wstring result;
 			for (auto&& ver : _impl) {
 				result += std::to_wstring(ver);
-				result += L'-';
+				result.append(a_separator.data(), a_separator.size());
 			}
-			result.pop_back();
+			result.erase(result.size() - a_separator.size(), a_separator.size());
 			return result;
 		}
 
@@ -609,7 +609,7 @@ namespace REL
 			const auto version = Module::get().version();
 			const auto path = std::format(
 				"Data/F4SE/Plugins/version-{}.bin",
-				version.string());
+				version.string("-"sv));
 			if (!_mmap.open(path)) {
 				stl::report_and_fail(std::format("failed to open: {}", path));
 			}

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -803,6 +803,18 @@ struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
 	}
 };
 
+#ifdef FMT_VERSION
+template<class CharT>
+struct fmt::formatter<REL::Version, CharT> : formatter<std::string, CharT>
+{
+    template<class FormatContext>
+    auto format(const REL::Version& a_version, FormatContext& a_ctx)
+	{
+		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+    }
+};
+#endif
+
 #undef REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE
 #undef REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE_HELPER
 #undef REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE_HELPER_IMPL

--- a/CommonLibF4/src/F4SE/API.cpp
+++ b/CommonLibF4/src/F4SE/API.cpp
@@ -83,6 +83,7 @@ namespace F4SE
 
 		if (a_log) {
 			log::init();
+			log::info("{} v{}", GetPluginName(), GetPluginVersion());
 		}
 
 		storage.messagingInterface = detail::QueryInterface<MessagingInterface>(a_intfc, LoadInterface::kMessaging);

--- a/CommonLibF4/src/F4SE/Logger.cpp
+++ b/CommonLibF4/src/F4SE/Logger.cpp
@@ -1,7 +1,12 @@
 #include "F4SE/Logger.h"
+#include "F4SE/API.h"
+#include "F4SE/Interfaces.h"
 
 #include "REX/W32/OLE32.h"
 #include "REX/W32/SHELL32.h"
+
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/msvc_sink.h>
 
 namespace F4SE::log
 {
@@ -16,7 +21,32 @@ namespace F4SE::log
 		}
 
 		std::filesystem::path path = knownPath.get();
-		path /= "My Games/Fallout4/F4SE"sv;
+		path /= std::format("My Games/{}/F4SE", F4SE::GetSaveFolderName());
 		return path;
+	}
+
+	void init()
+	{
+		auto path = log_directory();
+		if (!path)
+			return;
+
+		*path /= std::format("{}.log", F4SE::GetPluginName());
+
+		std::vector<spdlog::sink_ptr> sinks{
+			std::make_shared<spdlog::sinks::basic_file_sink_mt>(path->string(), true),
+			std::make_shared<spdlog::sinks::msvc_sink_mt>()
+		};
+
+		auto logger = std::make_shared<spdlog::logger>("global", sinks.begin(), sinks.end());
+#ifndef NDEBUG
+		logger->set_level(spdlog::level::debug);
+		logger->flush_on(spdlog::level::debug);
+#else
+		logger->set_level(spdlog::level::info);
+		logger->flush_on(spdlog::level::info);
+#endif
+		spdlog::set_default_logger(std::move(logger));
+		spdlog::set_pattern("[%T.%e] [%=5t] [%L] %v");
 	}
 }

--- a/CommonLibF4/xmake.lua
+++ b/CommonLibF4/xmake.lua
@@ -1,0 +1,183 @@
+-- define options
+option("f4se_xbyak", function()
+    set_default(false)
+    set_description("Enable trampoline support for Xbyak")
+    add_defines("F4SE_SUPPORT_XBYAK=1")
+end)
+
+-- define targets
+target("commonlibf4", function()
+    set_kind("static")
+
+    -- add packages
+    add_packages("rsm-binary-io", "rsm-mmio", "spdlog", { public = true })
+
+    if has_config("f4se_xbyak") then
+        add_packages("xbyak")
+    end
+
+    -- add options
+    add_options("f4se_xbyak", { public = true })
+
+    -- add system links
+    add_syslinks("advapi32", "bcrypt", "d3d11", "d3dcompiler", "dbghelp", "dxgi", "ole32", "shell32", "user32", "version")
+
+    -- add source files
+    add_files("src/**.cpp")
+
+    -- add header files
+    add_includedirs("include", { public = true })
+    add_headerfiles(
+        "include/(F4SE/**.h)",
+        "include/(RE/**.h)",
+        "include/(REL/**.h)",
+        "include/(REX/**.h)"
+    )
+
+    -- set precompiled header
+    set_pcxxheader("include/F4SE/Impl/PCH.h")
+
+    -- add flags
+    add_cxxflags("/EHsc", "/permissive-", { public = true })
+
+    -- add flags (cl)
+    add_cxxflags(
+        "cl::/bigobj",
+        "cl::/cgthreads8",
+        "cl::/diagnostics:caret",
+        "cl::/external:W0",
+        "cl::/fp:contract",
+        "cl::/fp:except-",
+        "cl::/guard:cf-",
+        "cl::/Zc:preprocessor",
+        "cl::/Zc:templateScope"
+    ) 
+
+    -- add flags (cl: disable warnings)
+    add_cxxflags(
+        "cl::/wd4200", -- nonstandard extension used : zero-sized array in struct/union
+        "cl::/wd4201", -- nonstandard extension used : nameless struct/union
+        "cl::/wd4324"  -- 'struct_name' : structure was padded due to __declspec(align())
+    )
+
+    -- add flags (cl: warnings -> errors)
+    add_cxxflags(
+        "cl::/we4715"  -- `function` : not all control paths return a value
+    )
+end)
+
+local PLUGIN_FILE = [[
+#include <F4SE/F4SE.h>
+F4SE_EXPORT constinit auto F4SEPlugin_Version = []() noexcept {
+    F4SE::PluginVersionData v{};
+    v.PluginVersion({ ${PLUGIN_VERSION_MAJOR}, ${PLUGIN_VERSION_MINOR}, ${PLUGIN_VERSION_PATCH}, 0 });
+    v.PluginName("${PLUGIN_NAME}");
+    v.AuthorName("${PLUGIN_AUTHOR}");
+    v.UsesAddressLibrary(true);
+    v.UsesSigScanning(false);
+    v.IsLayoutDependent(true);
+    v.HasNoStructUse(false);
+    v.CompatibleVersions({ F4SE::RUNTIME_LATEST });
+    return v;
+}();
+]]
+
+local PLUGIN_RC_FILE = [[
+#include <winres.h>
+
+1 VERSIONINFO
+FILEVERSION ${PLUGIN_VERSION_MAJOR}, ${PLUGIN_VERSION_MINOR}, ${PLUGIN_VERSION_PATCH}, 0
+PRODUCTVERSION ${PROJECT_VERSION_MAJOR}, ${PROJECT_VERSION_MINOR}, ${PROJECT_VERSION_PATCH}, 0
+FILEFLAGSMASK 0x17L
+#ifdef _DEBUG
+    FILEFLAGS 0x1L
+#else
+    FILEFLAGS 0x0L
+#endif
+FILEOS 0x4L
+FILETYPE 0x1L
+FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription", "${PLUGIN_DESCRIPTION}"
+            VALUE "FileVersion", "${PLUGIN_VERSION}.0"
+            VALUE "InternalName", "${PLUGIN_NAME}"
+            VALUE "LegalCopyright", "${PLUGIN_AUTHOR} | ${PLUGIN_LICENSE}"
+            VALUE "ProductName", "${PROJECT_NAME}"
+            VALUE "ProductVersion", "${PROJECT_VERSION}.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END]]
+
+-- git submodule usage:
+-- add_deps("commonlibf4")
+-- add_rules("commonlibf4.plugin", {
+--     name = "PluginName",
+--     author = "Author Name",
+--     description = "Plugin Description"
+-- })
+
+-- define rules
+rule("commonlibf4.plugin")
+    add_deps("win.sdk.resource")
+
+    on_config(function(target)
+        import("core.base.semver")
+        import("core.project.depend")
+        import("core.project.project")
+
+        target:set("arch", "x64")
+        target:set("kind", "shared")
+
+        local conf = target:extraconf("rules", "commonlibf4.plugin")
+        local conf_dir = path.join(target:autogendir(), "rules", "commonlibf4", "plugin")
+
+        local conf_map = {
+            PLUGIN_AUTHOR                = conf.author or "",
+            PLUGIN_DESCRIPTION           = conf.description or "",
+            PLUGIN_LICENSE               = (target:license() or "Unknown") .. " License",
+            PLUGIN_NAME                  = conf.name or target:name(),
+            PLUGIN_VERSION               = target:version() or "0.0.0",
+            PLUGIN_VERSION_MAJOR         = semver.new(target:version() or "0.0.0"):major(),
+            PLUGIN_VERSION_MINOR         = semver.new(target:version() or "0.0.0"):minor(),
+            PLUGIN_VERSION_PATCH         = semver.new(target:version() or "0.0.0"):patch(),
+            PROJECT_NAME                 = project.name() or "",
+            PROJECT_VERSION              = project.version() or "0.0.0",
+            PROJECT_VERSION_MAJOR        = semver.new(project.version() or "0.0.0"):major(),
+            PROJECT_VERSION_MINOR        = semver.new(project.version() or "0.0.0"):minor(),
+            PROJECT_VERSION_PATCH        = semver.new(project.version() or "0.0.0"):patch(),
+        }
+
+        local conf_parse = function(a_str)
+            return a_str:gsub("(%${([^\n]-)})", function(_, a_var)
+                local result = conf_map[a_var:trim()]
+                if type(result) ~= "string" then
+                    result = tostring(result)
+                end
+                assert(result ~= nil, "cannot get variable(%s)", a_var)
+                return result
+            end)
+        end
+
+        local add_file = function(a_path, a_data)
+            local file_path = path.join(conf_dir, a_path)
+            depend.on_changed(function()
+                local file = io.open(file_path, "w")
+                if file then
+                    file:write(conf_parse(a_data), "\n")
+                    file:close()
+                end
+            end, { dependfile = target:dependfile(file_path), files = project.allfiles()})
+            target:add("files", file_path)
+        end
+
+        add_file("plugin.cpp", PLUGIN_FILE)
+        add_file("version.rc", PLUGIN_RC_FILE)
+    end)

--- a/RTTIDump/src/PCH.h
+++ b/RTTIDump/src/PCH.h
@@ -18,11 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/msvc_sink.h>
-
-#define DLLEXPORT extern "C" [[maybe_unused]] __declspec(dllexport)
-
 namespace logger = F4SE::log;
 namespace stl = F4SE::stl;
 using namespace std::literals;

--- a/RTTIDump/src/main.cpp
+++ b/RTTIDump/src/main.cpp
@@ -391,8 +391,6 @@ F4SE_PLUGIN_LOAD(const F4SE::LoadInterface* a_f4se)
 {
 	F4SE::Init(a_f4se);
 
-	logger::info("{} v{}", F4SE::GetPluginName(), F4SE::GetPluginVersion());
-
 	auto messaging = F4SE::GetMessagingInterface();
 	messaging->RegisterListener(MessageHandler);
 

--- a/RTTIDump/src/main.cpp
+++ b/RTTIDump/src/main.cpp
@@ -387,32 +387,11 @@ void MessageHandler(F4SE::MessagingInterface::Message* a_message)
 	}
 }
 
-DLLEXPORT bool F4SEAPI F4SEPlugin_Load(const F4SE::LoadInterface* a_f4se)
+F4SE_PLUGIN_LOAD(const F4SE::LoadInterface* a_f4se)
 {
-	auto path = logger::log_directory();
-	if (!path) {
-		return false;
-	}
-
-	*path /= "RTTIDump.log"sv;
-
-	spdlog::sinks_init_list sinks{
-		std::make_shared<spdlog::sinks::basic_file_sink_mt>(path->string(), true),
-		std::make_shared<spdlog::sinks::msvc_sink_mt>()
-	};
-
-	auto log = std::make_shared<spdlog::logger>("global", sinks);
-#ifndef NDEBUG
-	log->set_level(spdlog::level::trace);
-#else
-	log->set_level(spdlog::level::info);
-	log->flush_on(spdlog::level::warn);
-#endif
-
-	spdlog::set_default_logger(std::move(log));
-	spdlog::set_pattern("%g(%#): [%^%l%$] %v");
-
 	F4SE::Init(a_f4se);
+
+	logger::info("{} v{}", F4SE::GetPluginName(), F4SE::GetPluginVersion());
 
 	auto messaging = F4SE::GetMessagingInterface();
 	messaging->RegisterListener(MessageHandler);
@@ -420,7 +399,7 @@ DLLEXPORT bool F4SEAPI F4SEPlugin_Load(const F4SE::LoadInterface* a_f4se)
 	return true;
 }
 
-DLLEXPORT constinit auto F4SEPlugin_Version = []() noexcept {
+F4SE_EXPORT constinit auto F4SEPlugin_Version = []() noexcept {
 	F4SE::PluginVersionData data{};
 
 	data.PluginName("rttidump");

--- a/RTTIDump/xmake.lua
+++ b/RTTIDump/xmake.lua
@@ -1,0 +1,24 @@
+target("rttidump")
+    -- set build kind
+    set_kind("shared")
+
+    -- set build by default
+    set_default(false)
+
+    -- set build group
+    set_group("plugin")
+
+    -- add dependencies
+    add_deps("commonlibf4")
+
+    -- add packages
+    add_packages("spdlog")
+
+    -- add source files
+    add_files("src/**.cpp")
+
+    -- add header files
+    add_includedirs("src")
+
+    -- set precompiled header
+    set_pcxxheader("src/pch.h")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,21 @@
+-- set minimum xmake version
+set_xmakever("2.8.2")
+
+-- set project
+set_project("commonlibf4")
+set_languages("c++23")
+set_warnings("allextra")
+set_encodings("utf-8")
+
+-- add rules
+add_rules("mode.debug", "mode.release")
+
+-- require packages
+add_requires("rsm-binary-io", "rsm-mmio", "xbyak")
+add_requires("spdlog", { configs = { header_only = false, wchar = true, std_format = true } })
+
+-- include subprojects
+includes("CommonLibF4")
+includes("AddressLibDecoder")
+includes("AddressLibGen")
+includes("RTTIDump")


### PR DESCRIPTION
- add default logger, enabled by default; uses plugin internal name for log file name
  - existing loggers will just get overwritten if initialized before `F4SE::Init`
  - can be disabled if necessary by passing `false` to `F4SE::Init(a_f4se, ...)`
- add `F4SE::` getters for plugin name, plugin author, and plugin version
  - also includes a getter for the new F4SE api function `GetSaveFolderName` introduced in `0.7.1`
- add shorthand `F4SE_*` macros for load and preload functions
- add missing include for the `__m128` type
  - not sure why this didn't result in a build error before...
- change `Version::(w)string` function to use `.` as the default separator, and allow for arbitrary user modification
- add `xmake` build support