### PR TITLE
feat: xmake | support plugin installation and packaging

### DIFF
--- a/CommonLibF4/include/REL/Version.h
+++ b/CommonLibF4/include/REL/Version.h
@@ -116,7 +116,7 @@ template <class CharT>
 struct fmt::formatter<REL::Version, CharT> : formatter<std::string, CharT>
 {
 	template <class FormatContext>
-	auto format(const REL::Version& a_version, FormatContext& a_ctx)
+	auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
 		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
 	}

--- a/CommonLibF4/xmake.lua
+++ b/CommonLibF4/xmake.lua
@@ -5,6 +5,11 @@ option("f4se_xbyak", function()
     add_defines("F4SE_SUPPORT_XBYAK=1")
 end)
 
+-- require packages
+if has_config("f4se_xbyak") then
+    add_requires("xbyak")
+end
+
 -- define targets
 target("commonlibf4", function()
     set_kind("static")

--- a/CommonLibF4/xmake.lua
+++ b/CommonLibF4/xmake.lua
@@ -14,6 +14,9 @@ end
 target("commonlibf4", function()
     set_kind("static")
 
+    -- set build by default
+    set_default(path.directory(os.scriptdir()) == os.projectdir())
+
     -- set build group
     set_group("commonlibf4")
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -11,7 +11,7 @@ set_encodings("utf-8")
 add_rules("mode.debug", "mode.releasedbg")
 
 -- require packages
-add_requires("rsm-binary-io", "rsm-mmio", "xbyak")
+add_requires("rsm-binary-io", "rsm-mmio")
 add_requires("spdlog", { configs = { header_only = false, wchar = true, std_format = true } })
 
 -- include subprojects


### PR DESCRIPTION
- when you build (or run `xmake install`) it will search for the environment variable `XSE_FO4_MODS_PATH` or `XSE_FO4_GAME_PATH` and copy install files (by default ".dll" and ".pdb") to the root path listed. More files can be added using `add_installfiles`.
  - the install path above can be overwritten using `set_installdir`
- when you run `xmake package` it will package the same files from above into a zip archive named after the target and the version.
- these events can be overwritten on a per-target basis if you wish to make your own install/package logic.